### PR TITLE
Handle empty cells during schema inference

### DIFF
--- a/lib/jsontableschema/infer.rb
+++ b/lib/jsontableschema/infer.rb
@@ -67,13 +67,15 @@ module JsonTableSchema
       guessed_type = 'string'
       guessed_format = 'default'
 
-      available_types.reverse_each do |type|
-        klass = get_class_for_type(type)
-        converter = Kernel.const_get(klass).new(@schema['fields'][index])
-        if converter.test(col) === true
-          guessed_type = type
-          guessed_format = guess_format(converter, col)
-          break
+      unless col.nil? || col == ""
+        available_types.reverse_each do |type|
+          klass = get_class_for_type(type)
+          converter = Kernel.const_get(klass).new(@schema['fields'][index])
+          if converter.test(col) === true
+            guessed_type = type
+            guessed_format = guess_format(converter, col)
+            break
+          end
         end
       end
 

--- a/spec/fixtures/data_infer_empty_fields.csv
+++ b/spec/fixtures/data_infer_empty_fields.csv
@@ -1,0 +1,5 @@
+id,age,name
+1,39,
+2,,Jimmy
+3,36,Jane
+4,28,Judy

--- a/spec/infer_spec.rb
+++ b/spec/infer_spec.rb
@@ -47,7 +47,23 @@ describe JsonTableSchema::Infer do
     expect(schema.get_field('currency')['type']).to eq('number')
     expect(schema.get_field('currency')['format']).to eq('currency')
   end
+  
+  it 'infers a schema with empty fields' do
+    @filename = 'data_infer_empty_fields.csv'
 
+    inferer = JsonTableSchema::Infer.new(headers, data)
+    schema = inferer.schema
+
+    expect(schema.get_field('id')['type']).to eq('integer')
+    expect(schema.get_field('id')['format']).to eq('default')
+
+    expect(schema.get_field('age')['type']).to eq('integer')
+    expect(schema.get_field('age')['format']).to eq('default')
+
+    expect(schema.get_field('name')['type']).to eq('string')
+    expect(schema.get_field('name')['format']).to eq('default')
+  end
+    
   it 'infers a schema with international characters' do
     @filename = 'data_infer_utf8.csv'
 


### PR DESCRIPTION
Currently, if a CSV has any empty cells, the inference won't work. Here, we fix by assuming that empty fields are the default type (i.e. string).

Fixes https://github.com/theodi/octopub/issues/410