### PR TITLE
Use hash keys consistently

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,20 @@
+AllCops:
+  DisabledByDefault: true
+  Exclude:
+    - 'lib/tableschema/exceptions.rb'
+
+Security:
+  Enabled: true
+
+Lint:
+  Enabled: true
+
+Style/HashSyntax:
+  Enabled: true
+  EnforcedStyle: ruby19_no_mixed_keys
+
+Style/MutableConstant:
+  Enabled: true
+
+Metrics/CyclomaticComplexity:
+  Severity: error

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,23 @@
 ---
 language: ruby
+
 rvm:
 - 2.3.1
 - 2.4.1
-before_install: gem install bundler -v 1.11.2
+
+before_install:
+  gem install bundler -v 1.11.2
+
+install:
+  - bundle
+  - gem install rubocop
+
+script:
+  - rake spec
+
+after_success:
+  - rubocop
+
 deploy:
   provider: rubygems
   api_key:

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require "open-uri"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec
 
 task :update_profiles do
   open('https://specs.frictionlessdata.io/schemas/table-schema.json') do |remote_schema|

--- a/lib/tableschema/constraints/constraints.rb
+++ b/lib/tableschema/constraints/constraints.rb
@@ -27,11 +27,11 @@ module TableSchema
     def validate!
       result = true
       @constraints.each do |c|
-        constraint = c.first
+        constraint = c.first.to_s
         if is_supported_type?(constraint)
           result = self.send("check_#{underscore constraint}")
         else
-          raise(TableSchema::ConstraintNotSupported.new("The field type `#{@field['type']}` does not support the `#{constraint}` constraint"))
+          raise(TableSchema::ConstraintNotSupported.new("The field type `#{@field[:type]}` does not support the `#{constraint}` constraint"))
         end
       end
       result
@@ -48,13 +48,13 @@ module TableSchema
     end
 
     def ordered_constraints
-      constraints = @field.fetch('constraints', {})
-      ordered_constraints = constraints.select{ |k,v| k == 'required'}
+      constraints = @field.fetch(:constraints, {})
+      ordered_constraints = constraints.select{ |k,v| k == :required}
       ordered_constraints.merge!(constraints)
     end
 
     def is_supported_type?(constraint)
-      klass = get_class_for_type(@field['type'])
+      klass = get_class_for_type(@field[:type])
       Kernel.const_get(klass).supported_constraints.include?(constraint)
     end
 

--- a/lib/tableschema/constraints/constraints.rb
+++ b/lib/tableschema/constraints/constraints.rb
@@ -49,7 +49,7 @@ module TableSchema
 
     def ordered_constraints
       constraints = @field.fetch(:constraints, {})
-      ordered_constraints = constraints.select{ |k,v| k == :required}
+      ordered_constraints = constraints.select{ |key| key == :required}
       ordered_constraints.merge!(constraints)
     end
 
@@ -59,20 +59,36 @@ module TableSchema
     end
 
     def parse_constraint(constraint)
-      if @value.is_a?(::Integer) && constraint.is_a?(::String)
-        constraint.to_i
-      elsif @value.is_a?(::Tod::TimeOfDay)
-        Tod::TimeOfDay.parse(constraint)
-      elsif @value.is_a?(::DateTime)
-        DateTime.parse(constraint)
-      elsif @value.is_a?(::Date) && constraint.is_a?(::String)
-        Date.parse(constraint)
-      elsif @value.is_a?(::Float) && constraint.is_a?(Array)
+      if constraint.is_a?(Array)
+        parse_array(constraint)
+      else
+        parse_string(constraint)
+      end
+    end
+
+    def parse_array(constraint)
+      case @value
+      when ::Float
         constraint.map { |c| Float(c) }
-      elsif @value.is_a?(Boolean) && constraint.is_a?(Array)
+      when ::Boolean
         constraint.map { |c| convert_to_boolean(c) }
-      elsif @value.is_a?(Date) && constraint.is_a?(Array)
+      when ::Date
         constraint.map { |c| Date.parse(c) }
+      else
+        constraint
+      end
+    end
+
+    def parse_string(constraint)
+      case @value
+      when ::Integer
+        constraint.to_i
+      when ::Tod::TimeOfDay
+        Tod::TimeOfDay.parse(constraint)
+      when ::DateTime
+        DateTime.parse(constraint)
+      when ::Date
+        Date.parse(constraint)
       else
         constraint
       end

--- a/lib/tableschema/constraints/enum.rb
+++ b/lib/tableschema/constraints/enum.rb
@@ -3,8 +3,8 @@ module TableSchema
     module Enum
 
       def check_enum
-        if !parse_constraint(@constraints['enum']).include?(@value)
-          raise TableSchema::ConstraintError.new("The value for the field `#{@field['name']}` must be in the enum array")
+        if !parse_constraint(@constraints[:enum]).include?(@value)
+          raise TableSchema::ConstraintError.new("The value for the field `#{@field[:name]}` must be in the enum array")
         end
         true
       end

--- a/lib/tableschema/constraints/max_length.rb
+++ b/lib/tableschema/constraints/max_length.rb
@@ -4,8 +4,8 @@ module TableSchema
 
       def check_max_length
         return if @value.nil?
-        if @value.length > @constraints['maxLength'].to_i
-          raise TableSchema::ConstraintError.new("The field `#{@field['name']}` must have a maximum length of #{@constraints['maxLength']}")
+        if @value.length > @constraints[:maxLength].to_i
+          raise TableSchema::ConstraintError.new("The field `#{@field[:name]}` must have a maximum length of #{@constraints[:maxLength]}")
         end
         true
       end

--- a/lib/tableschema/constraints/maximum.rb
+++ b/lib/tableschema/constraints/maximum.rb
@@ -3,8 +3,8 @@ module TableSchema
     module Maximum
 
       def check_maximum
-        if @value > parse_constraint(@constraints['maximum'])
-          raise TableSchema::ConstraintError.new("The field `#{@field['name']}` must not be more than #{@constraints['maximum']}")
+        if @value > parse_constraint(@constraints[:maximum])
+          raise TableSchema::ConstraintError.new("The field `#{@field[:name]}` must not be more than #{@constraints[:maximum]}")
         end
         true
       end

--- a/lib/tableschema/constraints/min_length.rb
+++ b/lib/tableschema/constraints/min_length.rb
@@ -4,8 +4,8 @@ module TableSchema
 
       def check_min_length
         return if @value.nil?
-        if @value.length < @constraints['minLength'].to_i
-          raise TableSchema::ConstraintError.new("The field `#{@field['name']}` must have a minimum length of #{@constraints['minLength']}")
+        if @value.length < @constraints[:minLength].to_i
+          raise TableSchema::ConstraintError.new("The field `#{@field[:name]}` must have a minimum length of #{@constraints[:minLength]}")
         end
         true
       end

--- a/lib/tableschema/constraints/minimum.rb
+++ b/lib/tableschema/constraints/minimum.rb
@@ -3,8 +3,8 @@ module TableSchema
     module Minimum
 
       def check_minimum
-        if @value < parse_constraint(@constraints['minimum'])
-          raise TableSchema::ConstraintError.new("The field `#{@field['name']}` must not be less than #{@constraints['minimum']}")
+        if @value < parse_constraint(@constraints[:minimum])
+          raise TableSchema::ConstraintError.new("The field `#{@field[:name]}` must not be less than #{@constraints[:minimum]}")
         end
         true
       end

--- a/lib/tableschema/constraints/pattern.rb
+++ b/lib/tableschema/constraints/pattern.rb
@@ -3,7 +3,7 @@ module TableSchema
     module Pattern
 
       def check_pattern
-        if !@value.to_json.match /#{@constraints[:pattern]}/
+        if !@value.to_json.match(/#{@constraints[:pattern]}/)
           raise TableSchema::ConstraintError.new("The value for the field `#{@field[:name]}` must match the pattern")
         end
         true

--- a/lib/tableschema/constraints/pattern.rb
+++ b/lib/tableschema/constraints/pattern.rb
@@ -3,8 +3,8 @@ module TableSchema
     module Pattern
 
       def check_pattern
-        if !@value.to_json.match /#{@constraints['pattern']}/
-          raise TableSchema::ConstraintError.new("The value for the field `#{@field['name']}` must match the pattern")
+        if !@value.to_json.match /#{@constraints[:pattern]}/
+          raise TableSchema::ConstraintError.new("The value for the field `#{@field[:name]}` must match the pattern")
         end
         true
       end

--- a/lib/tableschema/constraints/required.rb
+++ b/lib/tableschema/constraints/required.rb
@@ -4,7 +4,7 @@ module TableSchema
 
       def check_required
         if required == true && is_empty?
-          raise TableSchema::ConstraintError.new("The field `#{@field['name']}` requires a value")
+          raise TableSchema::ConstraintError.new("The field `#{@field[:name]}` requires a value")
         end
         true
       end
@@ -16,7 +16,7 @@ module TableSchema
       end
 
       def required
-        @constraints['required'].to_s == 'true'
+        @constraints[:required].to_s == 'true'
       end
     end
   end

--- a/lib/tableschema/data.rb
+++ b/lib/tableschema/data.rb
@@ -6,11 +6,10 @@ module TableSchema
     def cast_rows(rows, fail_fast = true, limit = nil)
       @errors ||= []
       parsed_rows = []
-      rows.each_with_index do |r, i|
+      rows.each_with_index do |row, i|
         begin
           break if limit && (limit <= i)
-          r = r.fields if r.class == CSV::Row
-          parsed_rows << cast_row(r, fail_fast)
+          parsed_rows << cast_row(row, fail_fast)
         rescue MultipleInvalid, ConversionError => e
           raise e if fail_fast == true
           @errors << e if e.is_a?(ConversionError)
@@ -24,6 +23,7 @@ module TableSchema
 
     def cast_row(row, fail_fast = true)
       @errors ||= []
+      row = row.fields if row.class == CSV::Row
       raise_header_error(row) if row.count != fields.count
       fields.each_with_index do |field,i|
         row[i] = cast_column(field, row[i], fail_fast)
@@ -46,7 +46,7 @@ module TableSchema
 
     def cast_column(field, col, fail_fast)
       field.cast_value(col)
-    rescue Exception => e
+    rescue TableSchema::Exception => e
       if fail_fast == true
         raise e
       else

--- a/lib/tableschema/defaults.rb
+++ b/lib/tableschema/defaults.rb
@@ -1,7 +1,7 @@
 module TableSchema
   DEFAULTS = {
-    'format' => 'default',
-    'type' => 'string',
-    'missing_values' => ['']
+    format: 'default',
+    type: 'string',
+    missing_values: ['']
   }
 end

--- a/lib/tableschema/defaults.rb
+++ b/lib/tableschema/defaults.rb
@@ -3,5 +3,5 @@ module TableSchema
     format: 'default',
     type: 'string',
     missing_values: ['']
-  }
+  }.freeze
 end

--- a/lib/tableschema/field.rb
+++ b/lib/tableschema/field.rb
@@ -6,26 +6,26 @@ module TableSchema
 
     attr_reader :type_class, :missing_values
 
-    def initialize(descriptor, missing_values=TableSchema::DEFAULTS['missing_values'])
-      self.merge! descriptor
+    def initialize(descriptor, missing_values=nil)
+      self.merge! deep_symbolize_keys(descriptor)
       @type_class = get_type
-      @missing_values = missing_values
+      @missing_values = missing_values || default_missing_values
     end
 
     def name
-      self['name']
+      self[:name]
     end
 
     def type
-      self['type'] || TableSchema::DEFAULTS['type']
+      self[:type] || TableSchema::DEFAULTS[:type]
     end
 
     def format
-      self['format'] || TableSchema::DEFAULTS['format']
+      self[:format] || TableSchema::DEFAULTS[:format]
     end
 
     def constraints
-      self['constraints'] || {}
+      self[:constraints] || {}
     end
 
     def cast_value(col)
@@ -35,6 +35,11 @@ module TableSchema
     end
 
     private
+
+      def default_missing_values
+        defaults = TableSchema::DEFAULTS[:missing_values]
+        self.type == 'string' ? defaults - [''] : defaults
+      end
 
       def get_type
         Object.const_get get_class_for_type(type)

--- a/lib/tableschema/helpers.rb
+++ b/lib/tableschema/helpers.rb
@@ -1,6 +1,21 @@
 module TableSchema
   module Helpers
 
+    def deep_symbolize_keys(descriptor)
+      case descriptor
+      when Hash
+        descriptor.inject({}) do |new_descriptor, (key, val)|
+          key_sym = key.respond_to?(:to_sym) ? key.to_sym : key
+          new_descriptor[key_sym] = deep_symbolize_keys(val)
+          new_descriptor
+        end
+      when Enumerable
+        descriptor.map{ |el| deep_symbolize_keys(el)}
+      else
+        descriptor
+      end
+    end
+
     def convert_to_boolean(value)
       if value.is_a?(Boolean)
         return value
@@ -22,24 +37,24 @@ module TableSchema
     end
 
     def get_class_for_type(type)
-      "TableSchema::Types::#{type_class_lookup[type] || 'String'}"
+      "TableSchema::Types::#{type_class_lookup[type.to_sym] || 'String'}"
     end
 
     def type_class_lookup
       {
-        'any' => 'Any',
-        'array' => 'Array',
-        'base' => 'Base',
-        'boolean' => 'Boolean',
-        'date' => 'Date',
-        'datetime' => 'DateTime',
-        'geojson' => 'GeoJSON',
-        'geopoint' => 'GeoPoint',
-        'integer' => 'Integer',
-        'number' => 'Number',
-        'object' => 'Object',
-        'string' => 'String',
-        'time' => 'Time',
+        any: 'Any',
+        array: 'Array',
+        base: 'Base',
+        boolean: 'Boolean',
+        date: 'Date',
+        datetime: 'DateTime',
+        geojson: 'GeoJSON',
+        geopoint: 'GeoPoint',
+        integer: 'Integer',
+        number: 'Number',
+        object: 'Object',
+        string: 'String',
+        time: 'Time',
       }
     end
 

--- a/lib/tableschema/infer.rb
+++ b/lib/tableschema/infer.rb
@@ -33,7 +33,7 @@ module TableSchema
         constraints = {}
         constraints[:required] = @explicit === true
         constraints[:unique] = (header == @primary_key)
-        constraints.delete_if { |k,v| v == false } unless @explicit === true
+        constraints.delete_if { |_,v| v == false } unless @explicit === true
         descriptor[:constraints] = constraints if constraints.count > 0
         TableSchema::Field.new(descriptor)
       end
@@ -41,8 +41,8 @@ module TableSchema
 
     def infer!
       type_matches = []
-      @rows.each_with_index do |row, i|
-        break if @row_limit && i > @row_limit
+      @rows.each_with_index do |row, index|
+        break if @row_limit && index > @row_limit
         row = row.fields if row.class == CSV::Row
 
         row_length = row.count
@@ -56,9 +56,9 @@ module TableSchema
           row = row.push(fill).flatten
         end
 
-        row.each_with_index do |col, i|
-          type_matches[i] ||= []
-          type_matches[i] << guess_type(col, i)
+        row.each_with_index do |col, idx|
+          type_matches[idx] ||= []
+          type_matches[idx] << guess_type(col, idx)
         end
 
       end
@@ -97,6 +97,7 @@ module TableSchema
           guessed_format = format
           break
         rescue TableSchema::Exception
+          next
         end
       end
       guessed_format

--- a/lib/tableschema/infer.rb
+++ b/lib/tableschema/infer.rb
@@ -16,25 +16,25 @@ module TableSchema
       @row_limit = opts[:row_limit]
 
       @schema = {
-        'fields' => fields
+        fields: fields
       }
-      @schema['primaryKey'] = @primary_key if @primary_key
+      @schema[:primaryKey] = @primary_key if @primary_key
       infer!
     end
 
     def fields
       @headers.map do |header|
         descriptor = {
-          'name' => header,
-          'title' => '',
-          'description' => '',
+          name: header,
+          title: '',
+          description: '',
         }
 
         constraints = {}
-        constraints['required'] = @explicit === true
-        constraints['unique'] = (header == @primary_key)
+        constraints[:required] = @explicit === true
+        constraints[:unique] = (header == @primary_key)
         constraints.delete_if { |k,v| v == false } unless @explicit === true
-        descriptor['constraints'] = constraints if constraints.count > 0
+        descriptor[:constraints] = constraints if constraints.count > 0
         TableSchema::Field.new(descriptor)
       end
     end
@@ -67,12 +67,12 @@ module TableSchema
     end
 
     def guess_type(col, index)
-      guessed_type = TableSchema::DEFAULTS['type']
-      guessed_format = TableSchema::DEFAULTS['format']
+      guessed_type = TableSchema::DEFAULTS[:type]
+      guessed_format = TableSchema::DEFAULTS[:format]
 
       available_types.reverse_each do |type|
         klass = get_class_for_type(type)
-        converter = Kernel.const_get(klass).new(@schema['fields'][index])
+        converter = Kernel.const_get(klass).new(@schema[:fields][index])
         if converter.test(col) === true
           guessed_type = type
           guessed_format = guess_format(converter, col)
@@ -81,18 +81,18 @@ module TableSchema
       end
 
       {
-        'type' => guessed_type,
-        'format' => guessed_format
+        type: guessed_type,
+        format: guessed_format
       }
     end
 
     def guess_format(converter, col)
-      guessed_format = TableSchema::DEFAULTS['format']
+      guessed_format = TableSchema::DEFAULTS[:format]
       converter.class.instance_methods.grep(/cast_/).each do |method|
         begin
           format = method.to_s
           format.slice!('cast_')
-          next if format == TableSchema::DEFAULTS['format']
+          next if format == TableSchema::DEFAULTS[:format]
           converter.send(method, col)
           guessed_format = format
           break
@@ -119,7 +119,7 @@ module TableSchema
           rv = sorted_counts[0][0]
         end
 
-        @schema['fields'][v].merge!(rv)
+        @schema[:fields][v].merge!(rv)
       end
 
     end

--- a/lib/tableschema/model.rb
+++ b/lib/tableschema/model.rb
@@ -4,38 +4,38 @@ module TableSchema
   module Model
 
     def headers
-      fields.map { |f| transform(f['name']) }
+      fields.map { |f| transform(f[:name]) }
     rescue NoMethodError
       []
     end
 
     def fields
-      self['fields']
+      self[:fields]
     end
 
     def primary_keys
-      [self['primaryKey']].flatten.reject { |k| k.nil? }
+      [self[:primaryKey]].flatten.reject { |k| k.nil? }
     end
 
     def foreign_keys
-      self['foreignKeys'] || []
+      self[:foreignKeys] || []
     end
 
     def missing_values
-      self.fetch('missingValues', TableSchema::DEFAULTS['missing_values'])
+      self.fetch(:missingValues, TableSchema::DEFAULTS[:missing_values])
     end
 
     def get_type(key)
-      get_field(key)['type']
+      get_field(key)[:type]
     end
 
     def get_constraints(key)
-      get_field(key)['constraints'] || {}
+      get_field(key)[:constraints] || {}
     end
 
     def required_headers
-      fields.select { |f| f['constraints']!= nil && f['constraints']['required'] == true }
-            .map { |f| transform(f['name']) }
+      fields.select { |f| f[:constraints]!= nil && f[:constraints][:required] == true }
+            .map { |f| transform(f[:name]) }
     rescue NoMethodError
       []
     end
@@ -45,11 +45,11 @@ module TableSchema
     end
 
     def get_field(key)
-      fields.find { |f| f['name'] == key }
+      fields.find { |f| f[:name] == key }
     end
 
     def get_fields_by_type(type)
-      fields.select { |f| f['type'] == type }
+      fields.select { |f| f[:type] == type }
     end
 
     private
@@ -60,14 +60,14 @@ module TableSchema
       end
 
       def expand!
-        (self['fields'] || []).each do |f|
-          f['type'] = TableSchema::DEFAULTS['type'] if f['type'] == nil
-          f['format'] = TableSchema::DEFAULTS['format'] if f['format'] == nil
+        (self[:fields] || []).each do |f|
+          f[:type] = TableSchema::DEFAULTS[:type] if f[:type] == nil
+          f[:format] = TableSchema::DEFAULTS[:format] if f[:format] == nil
         end
       end
 
       def load_fields!
-        self['fields'] = (self['fields'] || []).map { |f| TableSchema::Field.new(f, missing_values) }
+        self[:fields] = (self[:fields] || []).map { |f| TableSchema::Field.new(f, missing_values) }
       end
 
   end

--- a/lib/tableschema/schema.rb
+++ b/lib/tableschema/schema.rb
@@ -6,7 +6,7 @@ module TableSchema
     include TableSchema::Helpers
 
     def initialize(descriptor, opts = {})
-      self.merge! parse_schema(descriptor)
+      self.merge! deep_symbolize_keys(parse_schema(descriptor))
       @messages = []
       @opts = opts
       load_fields!
@@ -19,7 +19,7 @@ module TableSchema
         descriptor
       elsif descriptor.class == String
         begin
-          JSON.parse open(descriptor).read
+          JSON.parse(open(descriptor).read, symbolize_names: true)
         rescue Errno::ENOENT
           raise SchemaException.new("File not found at `#{descriptor}`")
         rescue OpenURI::HTTPError => e

--- a/lib/tableschema/table.rb
+++ b/lib/tableschema/table.rb
@@ -36,7 +36,7 @@ module TableSchema
 
       def coverted_to_hash(headers, array)
         array.map do |row|
-          Hash[row.map.with_index { |col, i| [headers[i], col] }]
+          Hash[row.map.with_index { |col, i| [headers[i].to_sym, col] }]
         end
       end
 

--- a/lib/tableschema/types/array.rb
+++ b/lib/tableschema/types/array.rb
@@ -22,7 +22,7 @@ module TableSchema
 
       def cast_default(value)
         return value if value.is_a?(type)
-        parsed = JSON.parse(value)
+        parsed = JSON.parse(value, symbolize_names: true)
         if parsed.is_a?(type)
           return parsed
         else

--- a/lib/tableschema/types/base.rb
+++ b/lib/tableschema/types/base.rb
@@ -8,9 +8,9 @@ module TableSchema
 
       def initialize(field)
         @field = field
-        @constraints = field['constraints'] || {}
-        @required = ['true', true].include?(@constraints['required'])
-        @type = @field['type']
+        @constraints = field[:constraints] || {}
+        @required = ['true', true].include?(@constraints[:required])
+        @type = @field[:type]
         set_format
       end
 
@@ -34,18 +34,17 @@ module TableSchema
       end
 
       def set_format
-        if (@field['format'] || '').start_with?('fmt:')
-          @format, @format_string = *@field['format'].split(':', 2)
+        if (@field[:format] || '').start_with?('fmt:')
+          @format, @format_string = *@field[:format].split(':', 2)
         else
-          @format = @field['format'] || TableSchema::DEFAULTS['format']
+          @format = @field[:format] || TableSchema::DEFAULTS[:format]
         end
       end
 
       private
 
         def is_null?(value)
-          null_values = @field.missing_values.reject{|el| el == '' && @type == 'string'}
-          null_values.include?(value)
+          @field.missing_values.include?(value)
         end
 
     end

--- a/lib/tableschema/types/geojson.rb
+++ b/lib/tableschema/types/geojson.rb
@@ -19,7 +19,7 @@ module TableSchema
       end
 
       def cast_default(value)
-        value = JSON.parse(value) if !value.is_a?(type)
+        value = JSON.parse(value, symbolize_names: true) if !value.is_a?(type)
         JSON::Validator.validate!(geojson_schema, value)
         value
       rescue JSON::Schema::ValidationError, JSON::ParserError
@@ -30,7 +30,7 @@ module TableSchema
 
       def geojson_schema
         path = File.join( File.dirname(__FILE__), "..", "..", "profiles", "geojson.json" )
-        @geojson_schema ||= JSON.parse File.read(path)
+        @geojson_schema ||= JSON.parse(File.read(path), symbolize_names: true)
       end
 
     end

--- a/lib/tableschema/types/geopoint.rb
+++ b/lib/tableschema/types/geopoint.rb
@@ -24,14 +24,14 @@ module TableSchema
       end
 
       def cast_object(value)
-        value = JSON.parse(value) if value.is_a?(::String)
-        cast_array([value['longitude'], value['latitude']])
+        value = JSON.parse(value, symbolize_names: true) if value.is_a?(::String)
+        cast_array([value[:longitude], value[:latitude]])
       rescue JSON::ParserError
         raise TableSchema::InvalidGeoPointType.new("#{value} is not a valid geopoint")
       end
 
       def cast_array(value)
-        value = JSON.parse(value) if value.is_a?(::String)
+        value = JSON.parse(value, symbolize_names: true) if value.is_a?(::String)
         value = [Float(value[0]), Float(value[1])]
         check_latlng_range(value)
         value

--- a/lib/tableschema/types/number.rb
+++ b/lib/tableschema/types/number.rb
@@ -25,11 +25,14 @@ module TableSchema
       end
 
       def cast_default(value)
-        return value if value.class == type
-        return Float(value) if value.class == ::Fixnum
-
-        value = preprocess_value(value)
-        return Float(value)
+        case value
+        when type
+          value
+        when ::Integer
+          Float(value)
+        else
+          Float(preprocess_value(value))
+        end
       rescue ArgumentError
         raise TableSchema::InvalidCast.new("#{value} is not a #{name}")
       end

--- a/lib/tableschema/types/number.rb
+++ b/lib/tableschema/types/number.rb
@@ -46,8 +46,8 @@ module TableSchema
       private
 
         def preprocess_value(value)
-          group_char = @field.fetch('groupChar', ',')
-          decimal_char = @field.fetch('decimalChar', '.')
+          group_char = @field.fetch(:groupChar, ',')
+          decimal_char = @field.fetch(:decimalChar, '.')
           percent_char = /%|‰|‱|％|﹪|٪/
           value.gsub(group_char, '')
                .gsub(decimal_char, '.')

--- a/lib/tableschema/types/object.rb
+++ b/lib/tableschema/types/object.rb
@@ -22,7 +22,7 @@ module TableSchema
 
       def cast_default(value)
         return value if value.is_a?(type)
-        parsed = JSON.parse(value)
+        parsed = JSON.parse(value, symbolize_names: true)
         if parsed.is_a?(Hash)
           return parsed
         else

--- a/lib/tableschema/validate.rb
+++ b/lib/tableschema/validate.rb
@@ -5,7 +5,7 @@ module TableSchema
 
     def load_validator!
       filepath = File.join(File.dirname(__FILE__), '..', 'profiles', 'table-schema.json')
-      @validator ||= JSON.parse(File.read filepath)
+      @validator ||= JSON.parse(File.read(filepath), symbolize_names: true)
     end
 
     def valid?
@@ -22,13 +22,13 @@ module TableSchema
     private
 
       def check_primary_keys
-        return if self['primaryKey'].nil?
+        return if self[:primaryKey].nil?
         primary_keys.each { |pk| check_field_value(pk, 'primaryKey') }
       end
 
       def check_foreign_keys
-        return if self['foreignKeys'].nil?
-        self['foreignKeys'].each do |key|
+        return if self[:foreignKeys].nil?
+        self[:foreignKeys].each do |key|
           foreign_key_fields(key).each { |fk| check_field_value(fk, 'foreignKey.fields') }
           if field_count_mismatch?(key)
             add_error("A JSON Table Schema foreignKey.fields must contain the same number entries as foreignKey.reference.fields.")
@@ -43,11 +43,11 @@ module TableSchema
       end
 
       def foreign_key_fields(key)
-        [key['fields']].flatten
+        [key[:fields]].flatten
       end
 
       def field_count_mismatch?(key)
-        key['reference'] && ([key['fields']].flatten.count != [key['reference']['fields']].flatten.count)
+        key[:reference] && ([key[:fields]].flatten.count != [key[:reference][:fields]].flatten.count)
       end
 
       def add_error(error)

--- a/lib/tableschema/version.rb
+++ b/lib/tableschema/version.rb
@@ -1,3 +1,3 @@
 module TableSchema
-  VERSION = "0.3.1"
+  VERSION = "0.3.1".freeze
 end

--- a/spec/constraints_spec.rb
+++ b/spec/constraints_spec.rb
@@ -4,10 +4,10 @@ describe TableSchema::Constraints do
 
   let(:field) {
     {
-      'name' => 'Name',
-      'type' => '',
-      'format' => 'default',
-      'constraints' => {}
+      name: 'Name',
+      type: '',
+      format: 'default',
+      constraints: {}
     }
   }
 
@@ -16,7 +16,7 @@ describe TableSchema::Constraints do
   describe TableSchema::Constraints::Required do
 
     before(:each) do
-      field['type'] = 'string'
+      field[:type] = 'string'
     end
 
     it 'handles an empty constraints hash' do
@@ -31,24 +31,24 @@ describe TableSchema::Constraints do
 
     it 'handles a required true constraint with a value' do
       @value = 'string'
-      field['constraints']['required'] = true
+      field[:constraints][:required] = true
       expect(constraints.validate!).to eq(true)
     end
 
     it 'handles a required false constraint with no value' do
       @value = ''
-      field['constraints']['required'] = false
+      field[:constraints][:required] = false
       expect(constraints.validate!).to eq(true)
     end
     it 'handles a required false constraint with a value' do
       @value = 'string'
-      field['constraints']['required'] = false
+      field[:constraints][:required] = false
       expect(constraints.validate!).to eq(true)
     end
 
     it 'raises an error for a required true constraint with no value' do
       @value = ''
-      field['constraints']['required'] = true
+      field[:constraints][:required] = true
       expect { constraints.validate! }.to raise_error(TableSchema::ConstraintError)
     end
 
@@ -59,8 +59,8 @@ describe TableSchema::Constraints do
     context 'with string type' do
 
       before(:each) do
-        field['type'] = 'string'
-        field['constraints']['minLength'] = 5
+        field[:type] = 'string'
+        field[:constraints][:minLength] = 5
       end
 
       it 'handles with a valid value' do
@@ -69,13 +69,13 @@ describe TableSchema::Constraints do
       end
 
       it 'handles when the value is equal' do
-        field['constraints']['minLength'] = 6
+        field[:constraints][:minLength] = 6
         @value = 'string'
         expect(constraints.validate!).to eq(true)
       end
 
       it 'handles with an invalid value' do
-        field['constraints']['minLength'] = 10
+        field[:constraints][:minLength] = 10
         @value = 'string'
         expect { constraints.validate! }.to raise_error(TableSchema::ConstraintError, 'The field `Name` must have a minimum length of 10')
       end
@@ -85,8 +85,8 @@ describe TableSchema::Constraints do
     context 'with array type' do
 
       before(:each) do
-        field['type'] = 'array'
-        field['constraints']['minLength'] = 2
+        field[:type] = 'array'
+        field[:constraints][:minLength] = 2
         @value = ['a', 'b', 'c']
       end
 
@@ -95,12 +95,12 @@ describe TableSchema::Constraints do
       end
 
       it 'handles when the value is equal' do
-        field['constraints']['minLength'] = 3
+        field[:constraints][:minLength] = 3
         expect(constraints.validate!).to eq(true)
       end
 
       it 'handles with an invalid value' do
-        field['constraints']['minLength'] = 10
+        field[:constraints][:minLength] = 10
         expect { constraints.validate! }.to raise_error(TableSchema::ConstraintError, 'The field `Name` must have a minimum length of 10')
       end
 
@@ -109,9 +109,9 @@ describe TableSchema::Constraints do
     context 'with object type' do
 
       before(:each) do
-        field['type'] = 'object'
-        field['constraints']['minLength'] = 2
-        @value = {'a' => 1, 'b' => 2, 'c' => 3}
+        field[:type] = 'object'
+        field[:constraints][:minLength] = 2
+        @value = {a: 1, b: 2, c: 3}
       end
 
       it 'handles with a valid value' do
@@ -119,12 +119,12 @@ describe TableSchema::Constraints do
       end
 
       it 'handles when the value is equal' do
-        field['constraints']['minLength'] = 3
+        field[:constraints][:minLength] = 3
         expect(constraints.validate!).to eq(true)
       end
 
       it 'handles with an invalid value' do
-        field['constraints']['minLength'] = 10
+        field[:constraints][:minLength] = 10
         expect { constraints.validate! }.to raise_error(TableSchema::ConstraintError, 'The field `Name` must have a minimum length of 10')
       end
 
@@ -132,8 +132,8 @@ describe TableSchema::Constraints do
 
     it 'raises for an unsupported type' do
       @value = 2
-      field['constraints']['minLength'] = 3
-      field['type'] = 'integer'
+      field[:constraints][:minLength] = 3
+      field[:type] = 'integer'
       expect { constraints.validate! }.to raise_error(TableSchema::ConstraintNotSupported, 'The field type `integer` does not support the `minLength` constraint')
     end
 
@@ -144,8 +144,8 @@ describe TableSchema::Constraints do
     context 'with string type' do
 
       before(:each) do
-        field['type'] = 'string'
-        field['constraints']['maxLength'] = 7
+        field[:type] = 'string'
+        field[:constraints][:maxLength] = 7
       end
 
       it 'handles with a valid value' do
@@ -154,13 +154,13 @@ describe TableSchema::Constraints do
       end
 
       it 'handles when the value is equal' do
-        field['constraints']['maxLength'] = 6
+        field[:constraints][:maxLength] = 6
         @value = 'string'
         expect(constraints.validate!).to eq(true)
       end
 
       it 'handles with an invalid value' do
-        field['constraints']['maxLength'] = 10
+        field[:constraints][:maxLength] = 10
         @value = 'stringggggggggggg'
         expect { constraints.validate! }.to raise_error(TableSchema::ConstraintError, 'The field `Name` must have a maximum length of 10')
       end
@@ -170,8 +170,8 @@ describe TableSchema::Constraints do
     context 'with array type' do
 
       before(:each) do
-        field['type'] = 'array'
-        field['constraints']['maxLength'] = 4
+        field[:type] = 'array'
+        field[:constraints][:maxLength] = 4
         @value = ['a', 'b', 'c']
       end
 
@@ -180,12 +180,12 @@ describe TableSchema::Constraints do
       end
 
       it 'handles when the value is equal' do
-        field['constraints']['maxLength'] = 3
+        field[:constraints][:maxLength] = 3
         expect(constraints.validate!).to eq(true)
       end
 
       it 'handles with an invalid value' do
-        field['constraints']['maxLength'] = 2
+        field[:constraints][:maxLength] = 2
         expect { constraints.validate! }.to raise_error(TableSchema::ConstraintError, 'The field `Name` must have a maximum length of 2')
       end
 
@@ -194,9 +194,9 @@ describe TableSchema::Constraints do
     context 'with object type' do
 
       before(:each) do
-        field['type'] = 'object'
-        field['constraints']['maxLength'] = 4
-        @value = {'a' => 1, 'b' => 2, 'c' => 3}
+        field[:type] = 'object'
+        field[:constraints][:maxLength] = 4
+        @value = {a: 1, b: 2, c: 3}
       end
 
       it 'handles with a valid value' do
@@ -204,12 +204,12 @@ describe TableSchema::Constraints do
       end
 
       it 'handles when the value is equal' do
-        field['constraints']['maxLength'] = 3
+        field[:constraints][:maxLength] = 3
         expect(constraints.validate!).to eq(true)
       end
 
       it 'handles with an invalid value' do
-        field['constraints']['maxLength'] = 2
+        field[:constraints][:maxLength] = 2
         expect { constraints.validate! }.to raise_error(TableSchema::ConstraintError, 'The field `Name` must have a maximum length of 2')
       end
 
@@ -217,8 +217,8 @@ describe TableSchema::Constraints do
 
     it 'raises for an unsupported type' do
       @value = 2
-      field['constraints']['maxLength'] = 3
-      field['type'] = 'integer'
+      field[:constraints][:maxLength] = 3
+      field[:type] = 'integer'
       expect { constraints.validate! }.to raise_error(TableSchema::ConstraintNotSupported, 'The field type `integer` does not support the `maxLength` constraint')
     end
 
@@ -229,8 +229,8 @@ describe TableSchema::Constraints do
     context 'with integer type' do
 
       before(:each) do
-        field['type'] = 'integer'
-        field['constraints']['minimum'] = 5
+        field[:type] = 'integer'
+        field[:constraints][:minimum] = 5
         @value = 20
       end
 
@@ -244,7 +244,7 @@ describe TableSchema::Constraints do
       end
 
       it 'handles with an invalid value' do
-        field['constraints']['minimum'] = 25
+        field[:constraints][:minimum] = 25
         expect { constraints.validate! }.to raise_error(TableSchema::ConstraintError, 'The field `Name` must not be less than 25')
       end
 
@@ -253,8 +253,8 @@ describe TableSchema::Constraints do
     context 'with date type' do
 
       before(:each) do
-        field['type'] = 'date'
-        field['constraints']['minimum'] = '1978-05-28'
+        field[:type] = 'date'
+        field[:constraints][:minimum] = '1978-05-28'
         @value = Date.parse('1978-05-29')
       end
 
@@ -277,8 +277,8 @@ describe TableSchema::Constraints do
     context 'with datetime type' do
 
       before(:each) do
-        field['type'] = 'date'
-        field['constraints']['minimum'] = '1978-05-28T12:30:20Z'
+        field[:type] = 'date'
+        field[:constraints][:minimum] = '1978-05-28T12:30:20Z'
         @value = DateTime.parse('1978-05-29T12:30:20Z')
       end
 
@@ -301,8 +301,8 @@ describe TableSchema::Constraints do
     context 'with time type' do
 
       before(:each) do
-        field['type'] = 'time'
-        field['constraints']['minimum'] = '11:30:00'
+        field[:type] = 'time'
+        field[:constraints][:minimum] = '11:30:00'
         @value = Tod::TimeOfDay.parse('12:30:20')
       end
 
@@ -324,8 +324,8 @@ describe TableSchema::Constraints do
 
     it 'raises for an unsupported type' do
       @value = 'sdsdasdsadsad'
-      field['constraints']['minimum'] = 3
-      field['type'] = 'string'
+      field[:constraints][:minimum] = 3
+      field[:type] = 'string'
       expect { constraints.validate! }.to raise_error(TableSchema::ConstraintNotSupported, 'The field type `string` does not support the `minimum` constraint')
     end
 
@@ -336,8 +336,8 @@ describe TableSchema::Constraints do
     context 'with integer type' do
 
       before(:each) do
-        field['type'] = 'integer'
-        field['constraints']['maximum'] = 5
+        field[:type] = 'integer'
+        field[:constraints][:maximum] = 5
         @value = 4
       end
 
@@ -351,7 +351,7 @@ describe TableSchema::Constraints do
       end
 
       it 'handles with an invalid value' do
-        field['constraints']['maximum'] = 2
+        field[:constraints][:maximum] = 2
         expect { constraints.validate! }.to raise_error(TableSchema::ConstraintError, 'The field `Name` must not be more than 2')
       end
 
@@ -360,8 +360,8 @@ describe TableSchema::Constraints do
     context 'with date type' do
 
       before(:each) do
-        field['type'] = 'date'
-        field['constraints']['maximum'] = '1978-05-28'
+        field[:type] = 'date'
+        field[:constraints][:maximum] = '1978-05-28'
         @value = Date.parse('1978-05-27')
       end
 
@@ -384,8 +384,8 @@ describe TableSchema::Constraints do
     context 'with datetime type' do
 
       before(:each) do
-        field['type'] = 'date'
-        field['constraints']['maximum'] = '1978-05-28T12:30:20Z'
+        field[:type] = 'date'
+        field[:constraints][:maximum] = '1978-05-28T12:30:20Z'
         @value = DateTime.parse('1978-05-27T12:30:20Z')
       end
 
@@ -408,8 +408,8 @@ describe TableSchema::Constraints do
     context 'with time type' do
 
       before(:each) do
-        field['type'] = 'time'
-        field['constraints']['maximum'] = '11:30:00'
+        field[:type] = 'time'
+        field[:constraints][:maximum] = '11:30:00'
         @value = Tod::TimeOfDay.parse('10:30:20')
       end
 
@@ -431,8 +431,8 @@ describe TableSchema::Constraints do
 
     it 'raises for an unsupported type' do
       @value = 'sdsdasdsadsad'
-      field['constraints']['maximum'] = 3
-      field['type'] = 'string'
+      field[:constraints][:maximum] = 3
+      field[:type] = 'string'
       expect { constraints.validate! }.to raise_error(TableSchema::ConstraintNotSupported, 'The field type `string` does not support the `maximum` constraint')
     end
 
@@ -443,8 +443,8 @@ describe TableSchema::Constraints do
     context 'with string type' do
 
       before(:each) do
-        field['type'] = 'string'
-        field['constraints']['enum'] = ['alice', 'bob', 'chuck']
+        field[:type] = 'string'
+        field[:constraints][:enum] = ['alice', 'bob', 'chuck']
         @value = 'bob'
       end
 
@@ -467,8 +467,8 @@ describe TableSchema::Constraints do
     context 'with integer type' do
 
       before(:each) do
-        field['type'] = 'integer'
-        field['constraints']['enum'] = [1,2,3]
+        field[:type] = 'integer'
+        field[:constraints][:enum] = [1,2,3]
         @value = 2
       end
 
@@ -486,8 +486,8 @@ describe TableSchema::Constraints do
     context 'with number type' do
 
       before(:each) do
-        field['type'] = 'number'
-        field['constraints']['enum'] = ["1.0","2.0","3.0"]
+        field[:type] = 'number'
+        field[:constraints][:enum] = ["1.0","2.0","3.0"]
         @value = Float(3)
       end
 
@@ -505,8 +505,8 @@ describe TableSchema::Constraints do
     context 'with boolean type' do
 
       before(:each) do
-        field['type'] = 'boolean'
-        field['constraints']['enum'] = [true]
+        field[:type] = 'boolean'
+        field[:constraints][:enum] = [true]
         @value = true
       end
 
@@ -520,7 +520,7 @@ describe TableSchema::Constraints do
       end
 
       it 'handles when value is equivalent to possible values in enum array' do
-        field['constraints']['enum'] = ['yes', 'y', 't', '1', 1]
+        field[:constraints][:enum] = ['yes', 'y', 't', '1', 1]
         expect(constraints.validate!).to eq(true)
       end
 
@@ -529,8 +529,8 @@ describe TableSchema::Constraints do
     context 'with array type' do
 
       before(:each) do
-        field['type'] = 'array'
-        field['constraints']['enum'] = [
+        field[:type] = 'array'
+        field[:constraints][:enum] = [
           ['first','second','third'],
           ['fred','alice','bob']
         ]
@@ -556,11 +556,11 @@ describe TableSchema::Constraints do
     context 'with object type' do
 
       before(:each) do
-        field['type'] = 'object'
-        field['constraints']['enum'] =  [{'a' => 'first',
-                                          'b' => 'second',
-                                          'c' => 'third'}]
-        @value = {'a' => 'first', 'b' => 'second', 'c' => 'third'}
+        field[:type] = 'object'
+        field[:constraints][:enum] =  [{a: 'first',
+                                          b: 'second',
+                                          c: 'third'}]
+        @value = {a: 'first', b: 'second', c: 'third'}
       end
 
       it 'handles with a valid value' do
@@ -569,15 +569,15 @@ describe TableSchema::Constraints do
 
       it 'handles with an invalid value' do
         @value = {
-            'a' => 'fred',
-            'b' => 'alice',
-            'c' => 'bob'
+            a: 'fred',
+            b: 'alice',
+            c: 'bob'
           }
         expect { constraints.validate! }.to raise_error(TableSchema::ConstraintError, 'The value for the field `Name` must be in the enum array')
       end
 
       it 'handles with a valid value and a different order' do
-        @value = {'b' => 'second', 'a' => 'first', 'c' => 'third'}
+        @value = {b: 'second', a: 'first', c: 'third'}
         expect(constraints.validate!).to eq(true)
       end
 
@@ -586,8 +586,8 @@ describe TableSchema::Constraints do
     context 'with date type' do
 
       before(:each) do
-        field['type'] = 'date'
-        field['constraints']['enum'] = ['2015-10-22']
+        field[:type] = 'date'
+        field[:constraints][:enum] = ['2015-10-22']
         @value = Date.parse('2015-10-22')
       end
 
@@ -609,8 +609,8 @@ describe TableSchema::Constraints do
     context 'with string type' do
 
         before(:each) do
-          field['type'] = 'string'
-          field['constraints']['pattern'] = '[0-9]{3}-[0-9]{2}-[0-9]{4}'
+          field[:type] = 'string'
+          field[:constraints][:pattern] = '[0-9]{3}-[0-9]{2}-[0-9]{4}'
           @value = '078-05-1120'
         end
 
@@ -628,8 +628,8 @@ describe TableSchema::Constraints do
     context 'with integer type' do
 
         before(:each) do
-          field['type'] = 'integer'
-          field['constraints']['pattern'] = '[7-9]{3}'
+          field[:type] = 'integer'
+          field[:constraints][:pattern] = '[7-9]{3}'
           @value = 789
         end
 
@@ -647,8 +647,8 @@ describe TableSchema::Constraints do
     context 'with number type' do
 
         before(:each) do
-          field['type'] = 'number'
-          field['constraints']['pattern'] = '7.[0-9]{3}'
+          field[:type] = 'number'
+          field[:constraints][:pattern] = '7.[0-9]{3}'
           @value = 7.123
         end
 
@@ -666,8 +666,8 @@ describe TableSchema::Constraints do
     context 'with array type' do
 
         before(:each) do
-          field['type'] = 'array'
-          field['constraints']['pattern'] = '\[("[a-c]",?\s?)*\]'
+          field[:type] = 'array'
+          field[:constraints][:pattern] = '\[("[a-c]",?\s?)*\]'
           @value = ['a', 'b', 'c']
         end
 
@@ -685,9 +685,9 @@ describe TableSchema::Constraints do
     context 'with object type' do
 
         before(:each) do
-          field['type'] = 'object'
-          field['constraints']['pattern'] = '\{("[a-z]":[0-9],?\s?)*\}'
-          @value = {'a' => 1, 'b' => 2, 'c' => 3}
+          field[:type] = 'object'
+          field[:constraints][:pattern] = '\{("[a-z]":[0-9],?\s?)*\}'
+          @value = {a: 1, b: 2, c: 3}
         end
 
         it 'handles with a valid value' do
@@ -695,7 +695,7 @@ describe TableSchema::Constraints do
         end
 
         it 'handles with an invalid value' do
-          @value = {'a' => 'fred', 'b' => 2, 'c' => 3}
+          @value = {a: 'fred', b: 2, c: 3}
           expect { constraints.validate! }.to raise_error(TableSchema::ConstraintError, 'The value for the field `Name` must match the pattern')
         end
 
@@ -704,8 +704,8 @@ describe TableSchema::Constraints do
     context 'with date type' do
 
         before(:each) do
-          field['type'] = 'date'
-          field['constraints']['pattern'] = '2015-[0-9]{2}-[0-9]{2}'
+          field[:type] = 'date'
+          field[:constraints][:pattern] = '2015-[0-9]{2}-[0-9]{2}'
           @value = '2015-01-23'
         end
 

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -3,45 +3,45 @@ require 'spec_helper'
 describe TableSchema::Data do
   let(:schema_hash) {
     {
-      "fields" => [
+      fields: [
           {
-              "name" => "id",
-              "type" => "string",
-              "constraints" => {
-                  "required" => true,
+              name: "id",
+              type: "string",
+              constraints: {
+                  required: true,
               }
           },
           {
-              "name" => "height",
-              "type" => "number",
-              "constraints" => {
-                  "required" => false,
+              name: "height",
+              type: "number",
+              constraints: {
+                  required: false,
               }
           },
           {
-              "name" => "age",
-              "type" => "integer",
-              "constraints" => {
-                  "required" => false,
+              name: "age",
+              type: "integer",
+              constraints: {
+                  required: false,
               }
           },
           {
-              "name" => "name",
-              "type" => "string",
-              "constraints" => {
-                  "required" => true,
+              name: "name",
+              type: "string",
+              constraints: {
+                  required: true,
               }
           },
           {
-              "name" => "occupation",
-              "type" => "string",
-              "constraints" => {
-                  "required" => false,
+              name: "occupation",
+              type: "string",
+              constraints: {
+                  required: false,
               }
           },
 
       ],
-      "missingValues" => [
+      missingValues: [
         '-',
         'null',
         ''

--- a/spec/field_spec.rb
+++ b/spec/field_spec.rb
@@ -3,12 +3,12 @@ require 'spec_helper'
 describe TableSchema::Field do
 
   before(:each) do
-    @descriptor_min = {'name' => 'id'}
+    @descriptor_min = {name: 'id'}
     @descriptor_max = {
-      'name' => 'amount',
-      'type' => 'number',
-      'format' => 'currency',
-      'constraints' => {'required' => true}
+      name: 'amount',
+      type: 'number',
+      format: 'currency',
+      constraints: {required: true}
     }
   end
 
@@ -26,13 +26,13 @@ describe TableSchema::Field do
   end
 
   it 'returns a format' do
-    expect(described_class.new(@descriptor_min).format).to eq(TableSchema::DEFAULTS['format'])
+    expect(described_class.new(@descriptor_min).format).to eq(TableSchema::DEFAULTS[:format])
     expect(described_class.new(@descriptor_max).format).to eq('currency')
   end
 
   it 'returns constraints' do
     expect(described_class.new(@descriptor_min).constraints).to eq({})
-    expect(described_class.new(@descriptor_max).constraints).to eq({'required' => true})
+    expect(described_class.new(@descriptor_max).constraints).to eq({required: true})
   end
 
   it 'returns the correct type class' do

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -4,17 +4,17 @@ describe TableSchema::Helpers do
 
   let(:schema_hash) {
     {
-    "fields" => [
+    fields: [
         {
-            "name" => "id",
-            "type" => "string",
-            "constraints" => {
-              "required" => true,
+            name: "id",
+            type: "string",
+            constraints: {
+              required: true,
             }
         },
         {
-            "name" => "height",
-            "type" => "number"
+            name: "height",
+            type: "number"
         }
       ]
     }
@@ -24,19 +24,19 @@ describe TableSchema::Helpers do
 
   it 'returns the right classes' do
     {
-      'any' => 'Any',
-      'array' => 'Array',
-      'base' => 'Base',
-      'boolean' => 'Boolean',
-      'date' => 'Date',
-      'datetime' => 'DateTime',
-      'geojson' => 'GeoJSON',
-      'geopoint' => 'GeoPoint',
-      'integer' => 'Integer',
-      'number' => 'Number',
-      'object' => 'Object',
-      'string' => 'String',
-      'time' => 'Time',
+      any: 'Any',
+      array: 'Array',
+      base: 'Base',
+      boolean: 'Boolean',
+      date: 'Date',
+      datetime: 'DateTime',
+      geojson: 'GeoJSON',
+      geopoint: 'GeoPoint',
+      integer: 'Integer',
+      number: 'Number',
+      object: 'Object',
+      string: 'String',
+      time: 'Time',
     }.each do |tipe, klass|
       expect(schema.get_class_for_type(tipe)).to eq("TableSchema::Types::#{klass}")
     end

--- a/spec/infer_spec.rb
+++ b/spec/infer_spec.rb
@@ -11,14 +11,14 @@ describe TableSchema::Infer do
     inferer = TableSchema::Infer.new(headers, data)
     schema = inferer.schema
 
-    expect(schema.get_field('id')['type']).to eq('integer')
-    expect(schema.get_field('id')['format']).to eq(TableSchema::DEFAULTS['format'])
+    expect(schema.get_field('id')[:type]).to eq('integer')
+    expect(schema.get_field('id')[:format]).to eq(TableSchema::DEFAULTS[:format])
 
-    expect(schema.get_field('age')['type']).to eq('integer')
-    expect(schema.get_field('age')['format']).to eq(TableSchema::DEFAULTS['format'])
+    expect(schema.get_field('age')[:type]).to eq('integer')
+    expect(schema.get_field('age')[:format]).to eq(TableSchema::DEFAULTS[:format])
 
-    expect(schema.get_field('name')['type']).to eq('string')
-    expect(schema.get_field('name')['format']).to eq(TableSchema::DEFAULTS['format'])
+    expect(schema.get_field('name')[:type]).to eq('string')
+    expect(schema.get_field('name')[:format]).to eq(TableSchema::DEFAULTS[:format])
   end
 
   it 'gets a format' do
@@ -38,14 +38,14 @@ describe TableSchema::Infer do
     inferer = TableSchema::Infer.new(headers, data)
     schema = inferer.schema
 
-    expect(schema.get_field('url')['type']).to eq('string')
-    expect(schema.get_field('url')['format']).to eq('uri')
+    expect(schema.get_field('url')[:type]).to eq('string')
+    expect(schema.get_field('url')[:format]).to eq('uri')
 
-    expect(schema.get_field('email')['type']).to eq('string')
-    expect(schema.get_field('email')['format']).to eq('email')
+    expect(schema.get_field('email')[:type]).to eq('string')
+    expect(schema.get_field('email')[:format]).to eq('email')
 
-    expect(schema.get_field('currency')['type']).to eq('number')
-    expect(schema.get_field('currency')['format']).to eq('currency')
+    expect(schema.get_field('currency')[:type]).to eq('number')
+    expect(schema.get_field('currency')[:format]).to eq('currency')
   end
 
   it 'infers a schema with international characters' do
@@ -54,14 +54,14 @@ describe TableSchema::Infer do
     inferer = TableSchema::Infer.new(headers, data)
     schema = inferer.schema
 
-    expect(schema.get_field('id')['type']).to eq('integer')
-    expect(schema.get_field('id')['format']).to eq(TableSchema::DEFAULTS['format'])
+    expect(schema.get_field('id')[:type]).to eq('integer')
+    expect(schema.get_field('id')[:format]).to eq(TableSchema::DEFAULTS[:format])
 
-    expect(schema.get_field('age')['type']).to eq('integer')
-    expect(schema.get_field('age')['format']).to eq(TableSchema::DEFAULTS['format'])
+    expect(schema.get_field('age')[:type]).to eq('integer')
+    expect(schema.get_field('age')[:format]).to eq(TableSchema::DEFAULTS[:format])
 
-    expect(schema.get_field('name')['type']).to eq('string')
-    expect(schema.get_field('name')['format']).to eq(TableSchema::DEFAULTS['format'])
+    expect(schema.get_field('name')[:type]).to eq('string')
+    expect(schema.get_field('name')[:format]).to eq(TableSchema::DEFAULTS[:format])
   end
 
   it 'infers a schema with a row limit' do
@@ -70,14 +70,14 @@ describe TableSchema::Infer do
     inferer = TableSchema::Infer.new(headers, data, row_limit: 4)
     schema = inferer.schema
 
-    expect(schema.get_field('id')['type']).to eq('integer')
-    expect(schema.get_field('id')['format']).to eq(TableSchema::DEFAULTS['format'])
+    expect(schema.get_field('id')[:type]).to eq('integer')
+    expect(schema.get_field('id')[:format]).to eq(TableSchema::DEFAULTS[:format])
 
-    expect(schema.get_field('age')['type']).to eq('integer')
-    expect(schema.get_field('age')['format']).to eq(TableSchema::DEFAULTS['format'])
+    expect(schema.get_field('age')[:type]).to eq('integer')
+    expect(schema.get_field('age')[:format]).to eq(TableSchema::DEFAULTS[:format])
 
-    expect(schema.get_field('name')['type']).to eq('string')
-    expect(schema.get_field('name')['format']).to eq(TableSchema::DEFAULTS['format'])
+    expect(schema.get_field('name')[:type]).to eq('string')
+    expect(schema.get_field('name')[:format]).to eq(TableSchema::DEFAULTS[:format])
   end
 
   it 'infers a schema with a primary key as a string' do
@@ -98,14 +98,14 @@ describe TableSchema::Infer do
     inferer = TableSchema::Infer.new(headers, data, explicit: true)
     schema = inferer.schema
 
-    expect(schema.get_field('id')['constraints']).to_not be_nil
+    expect(schema.get_field('id')[:constraints]).to_not be_nil
   end
 
   it 'lets us not be explicit' do
     inferer = TableSchema::Infer.new(headers, data, explicit: false)
     schema = inferer.schema
 
-    expect(schema.get_field('id')['constraints']).to be_nil
+    expect(schema.get_field('id')[:constraints]).to be_nil
   end
 
 end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -4,40 +4,40 @@ describe TableSchema::Model do
 
   let(:descriptor) {
     {
-      "fields" => [
+      fields: [
           {
-              "name" => "id",
-              "type" => "string",
-              "constraints" => {
-                  "required" => true,
+              name: "id",
+              type: "string",
+              constraints: {
+                  required: true,
               }
           },
           {
-              "name" => "height",
-              "type" => "number",
-              "constraints" => {
-                  "required" => false,
+              name: "height",
+              type: "number",
+              constraints: {
+                  required: false,
               }
           },
           {
-              "name" => "age",
-              "type" => "integer",
-              "constraints" => {
-                  "required" => false,
+              name: "age",
+              type: "integer",
+              constraints: {
+                  required: false,
               }
           },
           {
-              "name" => "name",
-              "type" => "string",
-              "constraints" => {
-                  "required" => true,
+              name: "name",
+              type: "string",
+              constraints: {
+                  required: true,
               }
           },
           {
-              "name" => "occupation",
-              "type" => "string",
-              "constraints" => {
-                  "required" => false,
+              name: "occupation",
+              type: "string",
+              constraints: {
+                  required: false,
               }
           },
 
@@ -47,12 +47,12 @@ describe TableSchema::Model do
 
   let(:schema_min) {
     {
-      "fields" => [
+      fields: [
           {
-              "name" => "id"
+              name: "id"
           },
           {
-              "name" => "height"
+              name: "height"
           }
       ]
     }
@@ -108,7 +108,7 @@ describe TableSchema::Model do
 
     it 'gets the constraints for a field' do
       s = TableSchema::Schema.new(descriptor)
-      expect(s.get_constraints('id')).to eq({"required" => true})
+      expect(s.get_constraints('id')).to eq({required: true})
     end
 
     it 'returns an empty hash where there are no constraints' do
@@ -122,7 +122,7 @@ describe TableSchema::Model do
 
     let(:new_descriptor) {
       new_descriptor = descriptor.dup
-      new_descriptor['fields'].map { |f| f['name'].capitalize! }
+      new_descriptor[:fields].map { |f| f[:name].capitalize! }
       new_descriptor
     }
 
@@ -145,9 +145,9 @@ describe TableSchema::Model do
 
   it 'does not set fields as required by default' do
      hash = {
-       "fields" => [
-        {"name" => "id", "constraints" => {"required" => true}},
-        {"name" => "label"}
+       fields: [
+        {name: "id", constraints: {required: true}},
+        {name: "label"}
        ]
      }
 
@@ -183,11 +183,11 @@ describe TableSchema::Model do
       schema = TableSchema::Schema.new(descriptor)
       expect(schema.foreign_keys).to eq([
         {
-            "fields" => "state",
-            "reference" => {
-                "datapackage" => "http://data.okfn.org/data/mydatapackage/",
-                "resource" => "the-resource",
-                "fields" => "state_id"
+            fields: "state",
+            reference: {
+                datapackage: "http://data.okfn.org/data/mydatapackage/",
+                resource: "the-resource",
+                fields: "state_id"
             }
         }
       ])
@@ -198,11 +198,11 @@ describe TableSchema::Model do
       schema = TableSchema::Schema.new(descriptor)
       expect(schema.foreign_keys).to eq([
         {
-            "fields" => "parent",
-            "reference" => {
-                "datapackage" => "",
-                "resource" => "self",
-                "fields" => "id"
+            fields: "parent",
+            reference: {
+                datapackage: "",
+                resource: "self",
+                fields: "id"
             }
         }
       ])
@@ -213,11 +213,11 @@ describe TableSchema::Model do
       schema = TableSchema::Schema.new(descriptor)
       expect(schema.foreign_keys).to eq([
           {
-              "fields" => ["id", "title"],
-              "reference" => {
-                  "datapackage" => "http://data.okfn.org/data/mydatapackage/",
-                  "resource" => "the-resource",
-                  "fields" => ["fk_id", "title_id"]
+              fields: ["id", "title"],
+              reference: {
+                  datapackage: "http://data.okfn.org/data/mydatapackage/",
+                  resource: "the-resource",
+                  fields: ["fk_id", "title_id"]
               }
           }
       ])

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -7,14 +7,14 @@ describe TableSchema::Schema do
     it 'with a hash' do
       hash = load_descriptor('schema_valid_full.json')
       schema = TableSchema::Schema.new(hash)
-      expect(schema['fields'].count).to eq(22)
-      expect(schema['fields'].first.class).to eq(TableSchema::Field)
+      expect(schema[:fields].count).to eq(22)
+      expect(schema[:fields].first.class).to eq(TableSchema::Field)
     end
 
     it 'with a file' do
       file = File.join( File.dirname(__FILE__), "fixtures", "schema_valid_full.json")
       schema = TableSchema::Schema.new(file)
-      expect(schema['fields'].count).to eq(22)
+      expect(schema[:fields].count).to eq(22)
     end
 
     it 'with a url' do
@@ -24,7 +24,7 @@ describe TableSchema::Schema do
                   .to_return(body: File.open(path))
 
       schema = TableSchema::Schema.new(url)
-      expect(schema['fields'].count).to eq(22)
+      expect(schema[:fields].count).to eq(22)
     end
 
     context 'raises an exception' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,5 +7,5 @@ require 'webmock/rspec'
 
 def load_descriptor(filename)
   body = File.read File.join( File.dirname(__FILE__), "fixtures", filename)
-  JSON.parse(body)
+  JSON.parse(body, symbolize_names: true)
 end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -10,18 +10,18 @@ describe TableSchema::Table do
 
   it 'loads a schema' do
     expect(table.schema).to eq({
-      "fields" => [
+      fields: [
         {
-          "name"=>"id",
-          "title"=>"Identifier",
-          "type"=>"integer",
-          "format"=>"default"
+          name: "id",
+          title: "Identifier",
+          type: "integer",
+          format: "default"
         },
         {
-          "name"=>"title",
-          "title"=>"Title",
-          "type"=>"string",
-          "format"=>"default"
+          name: "title",
+          title: "Title",
+          type: "string",
+          format: "default"
         }
       ]
     })
@@ -67,9 +67,9 @@ describe TableSchema::Table do
 
   it 'returns keyed rows' do
     expect(table.rows(keyed: true)).to eq([
-      { 'id' => 1, 'title' => 'foo'},
-      { 'id' => 2, 'title' => 'bar'},
-      { 'id' => 3, 'title' => 'baz'},
+      { id: 1, title: 'foo'},
+      { id: 2, title: 'bar'},
+      { id: 3, title: 'baz'},
     ])
   end
 
@@ -116,20 +116,20 @@ describe TableSchema::Table do
   it 'infers a schema' do
     table = TableSchema::Table.infer_schema(csv)
     expect(table.schema).to eq({
-      "fields" => [
+      fields: [
         {
-          "name"=>"id",
-          "title"=>"",
-          "description"=>"",
-          "type"=>"integer",
-          "format"=>"default"
+          name: "id",
+          title: "",
+          description: "",
+          type: "integer",
+          format: "default"
         },
         {
-          "name"=>"title",
-          "title"=>"",
-          "description"=>"",
-          "type"=>"string",
-          "format"=>"default"
+          name: "title",
+          title: "",
+          description: "",
+          type: "string",
+          format: "default"
         }
       ]
     })

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -6,11 +6,11 @@ describe TableSchema::Types do
 
     let(:field) {
       TableSchema::Field.new({
-        'name' => 'Name',
-        'type' => 'string',
-        'format' => 'default',
-        'constraints' => {
-          'required' => true
+        name: 'Name',
+        type: 'string',
+        format: 'default',
+        constraints: {
+          required: true
         }
       })
     }
@@ -28,7 +28,7 @@ describe TableSchema::Types do
     end
 
     it 'raises for an unsupported format' do
-      field['format'] = 'foo'
+      field[:format] = 'foo'
       value = 'foo'
       expect { type.cast(value) }.to raise_error(TableSchema::InvalidFormat)
     end
@@ -36,7 +36,7 @@ describe TableSchema::Types do
     context 'emails' do
 
       before(:each) do
-        field['format'] = 'email'
+        field[:format] = 'email'
       end
 
       it 'casts an email' do
@@ -63,7 +63,7 @@ describe TableSchema::Types do
     context 'uris' do
 
       before(:each) do
-        field['format'] = 'uri'
+        field[:format] = 'uri'
       end
 
       it 'casts a uri' do
@@ -81,7 +81,7 @@ describe TableSchema::Types do
     context 'uuid' do
 
       before(:each) do
-        field['format'] = 'uuid'
+        field[:format] = 'uuid'
       end
 
 
@@ -115,11 +115,11 @@ describe TableSchema::Types do
 
     let(:field) {
       TableSchema::Field.new({
-        'name' => 'Name',
-        'type' => 'number',
-        'format' => 'default',
-        'constraints' => {
-          'required' => true
+        name: 'Name',
+        type: 'number',
+        format: 'default',
+        constraints: {
+          required: true
         }
       })
     }
@@ -134,7 +134,7 @@ describe TableSchema::Types do
     it 'casts when the value is already cast' do
       [1, 1.0, Float(1)].each do |value|
         ['default', 'currency'].each do |format|
-          field['format'] = format
+          field[:format] = format
           expect(type.cast(value)).to eq(Float(value))
         end
       end
@@ -157,7 +157,7 @@ describe TableSchema::Types do
         expect { type.cast(value) }.to_not raise_error
       end
 
-      field['groupChar'] = '#'
+      field[:groupChar] = '#'
 
       [
         '10#000.00',
@@ -168,7 +168,7 @@ describe TableSchema::Types do
         expect { type.cast(value) }.to_not raise_error
       end
 
-      field['decimalChar'] = '@'
+      field[:decimalChar] = '@'
 
       [
         '10#000@00',
@@ -184,7 +184,7 @@ describe TableSchema::Types do
     context 'currencies' do
 
       let(:currency_field) {
-        field['format'] = 'currency'
+        field[:format] = 'currency'
         field
       }
 
@@ -202,8 +202,8 @@ describe TableSchema::Types do
           expect { currency_type.cast(value) }.to_not raise_error
         end
 
-        field['decimalChar'] = ','
-        field['groupChar'] = ' '
+        field[:decimalChar] = ','
+        field[:groupChar] = ' '
 
         [
           '10 000,00',
@@ -233,11 +233,11 @@ describe TableSchema::Types do
 
     let(:field) {
       TableSchema::Field.new({
-        'name' => 'Name',
-        'type' => 'integer',
-        'format' => 'default',
-        'constraints' => {
-          'required' => true
+        name: 'Name',
+        type: 'integer',
+        format: 'default',
+        constraints: {
+          required: true
         }
       })
     }
@@ -265,11 +265,11 @@ describe TableSchema::Types do
 
     let(:field) {
       TableSchema::Field.new({
-        'name' => 'Name',
-        'type' => 'boolean',
-        'format' => 'default',
-        'constraints' => {
-          'required' => true
+        name: 'Name',
+        type: 'boolean',
+        format: 'default',
+        constraints: {
+          required: true
         }
       })
     }
@@ -312,11 +312,11 @@ describe TableSchema::Types do
 
     let(:field) {
       TableSchema::Field.new({
-        'name' => 'Name',
-        'type' => 'object',
-        'format' => 'default',
-        'constraints' => {
-          'required' => true
+        name: 'Name',
+        type: 'object',
+        format: 'default',
+        constraints: {
+          required: true
         }
       })
     }
@@ -324,13 +324,13 @@ describe TableSchema::Types do
     let(:type) { TableSchema::Types::Object.new(field) }
 
     it 'casts a hash' do
-      value = {'key' => 'value'}
+      value = {key: 'value'}
       expect(type.cast(value)).to eq(value)
     end
 
     it 'casts JSON string' do
       value = '{"key": "value"}'
-      expect(type.cast(value)).to eq(JSON.parse(value))
+      expect(type.cast(value)).to eq(JSON.parse(value, symbolize_names: true))
     end
 
     it 'raises when value is not a hash' do
@@ -349,11 +349,11 @@ describe TableSchema::Types do
 
     let(:field) {
       TableSchema::Field.new({
-        'name' => 'Name',
-        'type' => 'array',
-        'format' => 'default',
-        'constraints' => {
-          'required' => true
+        name: 'Name',
+        type: 'array',
+        format: 'default',
+        constraints: {
+          required: true
         }
       })
     }
@@ -386,11 +386,11 @@ describe TableSchema::Types do
 
     let(:field) {
       TableSchema::Field.new({
-        'name' => 'Name',
-        'type' => 'date',
-        'format' => 'default',
-        'constraints' => {
-          'required' => true
+        name: 'Name',
+        type: 'date',
+        format: 'default',
+        constraints: {
+          required: true
         }
       })
     }
@@ -409,44 +409,44 @@ describe TableSchema::Types do
 
     it 'casts any parseable date' do
       value = '10th Jan 1969'
-      field['format'] = 'any'
+      field[:format] = 'any'
       expect(type.cast(value)).to eq(Date.new(1969,01,10))
     end
 
     it 'raises an error for any when date is unparsable' do
       value = '10th Jan nineteen sixty nine'
-      field['format'] = 'any'
+      field[:format] = 'any'
       expect { type.cast(value) }.to raise_error(TableSchema::InvalidDateType)
     end
 
     it 'casts with a specified date format' do
       value = '10/06/2014'
-      field['format'] = 'fmt:%d/%m/%Y'
+      field[:format] = 'fmt:%d/%m/%Y'
       expect(type.cast(value)).to eq(Date.new(2014,06,10))
     end
 
     it 'assumes the first day of the month' do
       value = '2014-06'
-      field['format'] = 'fmt:%Y-%m'
+      field[:format] = 'fmt:%Y-%m'
       expect(type.cast(value)).to eq(Date.new(2014,06,01))
     end
 
     it 'raises an error for an invalid fmt' do
       value = '2014/12/19'
-      field['format'] = 'fmt:DD/MM/YYYY'
+      field[:format] = 'fmt:DD/MM/YYYY'
       expect { type.cast(value) }.to raise_error(TableSchema::InvalidDateType)
     end
 
     it 'raises an error for a valid fmt and invalid value' do
       value = '2014/12/19'
-      field['format'] = 'fmt:%m/%d/%y'
+      field[:format] = 'fmt:%m/%d/%y'
       expect { type.cast(value) }.to raise_error(TableSchema::InvalidDateType)
     end
 
     it 'works with an already cast value' do
       value = Date.new(2014,06,01)
       ['default', 'any', 'fmt:%Y-%m-%d'].each do |f|
-        field['format'] = f
+        field[:format] = f
         expect(type.cast(value)).to eq(value)
       end
     end
@@ -457,11 +457,11 @@ describe TableSchema::Types do
 
     let(:field) {
       TableSchema::Field.new({
-        'name' => 'Name',
-        'type' => 'time',
-        'format' => 'default',
-        'constraints' => {
-          'required' => true
+        name: 'Name',
+        type: 'time',
+        format: 'default',
+        constraints: {
+          required: true
         }
       })
     }
@@ -480,19 +480,19 @@ describe TableSchema::Types do
 
     it 'parses a generic time string' do
       value = '3:00 am'
-      field['format'] = 'any'
+      field[:format] = 'any'
       expect(type.cast(value)).to eq(Tod::TimeOfDay.new(3,0))
     end
 
     it 'raises when a time string is invalid' do
       value = 'Flava Flav'
-      field['format'] = 'any'
+      field[:format] = 'any'
       expect { type.cast(value) }.to raise_error(TableSchema::InvalidTimeType)
     end
 
     it 'raises an error when type format is incorrect' do
       value = 3.00
-      self.field['format'] = 'fmt:any'
+      self.field[:format] = 'fmt:any'
       expect { type.cast(value) }.to raise_error(TableSchema::InvalidTimeType)
 
       value = {}
@@ -505,7 +505,7 @@ describe TableSchema::Types do
     it 'works with an already cast value' do
       value = Tod::TimeOfDay.new(06,00)
       ['default', 'any', 'fmt:any'].each do |f|
-        field['format'] = f
+        field[:format] = f
         expect(type.cast(value)).to eq(value)
       end
     end
@@ -516,11 +516,11 @@ describe TableSchema::Types do
 
     let(:field) {
       TableSchema::Field.new({
-        'name' => 'Name',
-        'type' => 'datetime',
-        'format' => 'default',
-        'constraints' => {
-          'required' => true
+        name: 'Name',
+        type: 'datetime',
+        format: 'default',
+        constraints: {
+          required: true
         }
       })
     }
@@ -534,13 +534,13 @@ describe TableSchema::Types do
 
     it 'guesses when fomat is any' do
       value = '10th Jan 1969 9am'
-      field['format'] = 'any'
+      field[:format] = 'any'
       expect(type.cast(value)).to eq(DateTime.new(1969,01,10,9,0,0))
     end
 
     it 'accepts a specified format' do
       value = '21/11/06 16:30'
-      field['format'] = 'fmt:%d/%m/%y %H:%M'
+      field[:format] = 'fmt:%d/%m/%y %H:%M'
       expect(type.cast(value)).to eq(DateTime.new(2006,11,21,16,30,00))
     end
 
@@ -551,20 +551,20 @@ describe TableSchema::Types do
 
     it 'raises an exception for an unparsable datetime' do
       value = 'the land before time'
-      field['format'] = 'any'
+      field[:format] = 'any'
       expect { type.cast(value) }.to raise_error(TableSchema::InvalidDateTimeType)
     end
 
     it 'raises if the date format is invalid' do
       value = '21/11/06 16:30'
-      field['format'] = 'fmt:notavalidformat'
+      field[:format] = 'fmt:notavalidformat'
       expect { type.cast(value) }.to raise_error(TableSchema::InvalidDateTimeType)
     end
 
     it 'works fine with an already cast value' do
       value = DateTime.new(2015, 1, 1, 12, 0, 0)
       ['default', 'any', 'fmt:any'].each do |format|
-        field['format'] = format
+        field[:format] = format
         expect(type.cast(value)).to eq(value)
       end
     end
@@ -575,11 +575,11 @@ describe TableSchema::Types do
 
     let(:field) {
       TableSchema::Field.new({
-        'name' => 'Name',
-        'type' => 'geojson',
-        'format' => 'default',
-        'constraints' => {
-          'required' => false
+        name: 'Name',
+        type: 'geojson',
+        format: 'default',
+        constraints: {
+          required: false
         }
       })
     }
@@ -587,17 +587,17 @@ describe TableSchema::Types do
     let(:type) { TableSchema::Types::GeoJSON.new(field) }
 
     it 'raises with invalid GeoJSON' do
-      value = {'coordinates' => [0, 0, 0], 'type' =>'Point'}
+      value = {coordinates: [0, 0, 0], type:'Point'}
         expect { type.cast(value) }.to raise_error(TableSchema::InvalidGeoJSONType)
     end
 
     it 'handles a GeoJSON hash' do
       value = {
-        "properties" => {
-          "Ã" => "Ã"
+        properties: {
+          Ã: "Ã"
         },
-        "type" => "Feature",
-        "geometry" => nil,
+        type: "Feature",
+        geometry: nil,
       }
 
       expect(type.cast(value)).to eq(value)
@@ -606,7 +606,7 @@ describe TableSchema::Types do
     it 'handles a GeoJSON string' do
       value = '{"geometry": null, "type": "Feature", "properties": {"\\u00c3": "\\u00c3"}}'
 
-      expect(type.cast(value)).to eq(JSON.parse value)
+      expect(type.cast(value)).to eq(JSON.parse(value, symbolize_names: true))
     end
 
     it 'raises with an invalid JSON string' do
@@ -626,11 +626,11 @@ describe TableSchema::Types do
 
     let(:field) {
       TableSchema::Field.new({
-        'name' => 'Name',
-        'type' => 'geopoint',
-        'format' => 'default',
-        'constraints' => {
-          'required' => true
+        name: 'Name',
+        type: 'geopoint',
+        format: 'default',
+        constraints: {
+          required: true
         }
       })
     }
@@ -668,7 +668,7 @@ describe TableSchema::Types do
     end
 
     it 'handles an array' do
-      field['format'] = 'array'
+      field[:format] = 'array'
       value = [10.0, 21.00]
       expect(type.cast(value)).to eq([Float(10.0), Float(21.00)])
       value = ["10.0", "21.00"]
@@ -676,13 +676,13 @@ describe TableSchema::Types do
     end
 
     it 'handles an array as a JSON string' do
-      field['format'] = 'array'
+      field[:format] = 'array'
       value = '[10.0, 21.00]'
       expect(type.cast(value)).to eq([Float(10.0), Float(21.00)])
     end
 
     it 'raises for an invalid array' do
-      field['format'] = 'array'
+      field[:format] = 'array'
       value = '1,2'
       expect { type.cast(value) }.to raise_error(TableSchema::InvalidGeoPointType)
       value = '["a", "b"]'
@@ -692,21 +692,21 @@ describe TableSchema::Types do
     end
 
     it 'handles an object' do
-      field['format'] = 'object'
-      value = {"longitude" => 10.0, "latitude" => 21.00}
+      field[:format] = 'object'
+      value = {longitude: "10.0", latitude: "21.00"}
       expect(type.cast(value)).to eq([Float(10.0), Float(21.00)])
-      value = {"longitude" => "10.0", "latitude" => "21.00"}
+      value = {longitude: "10.0", latitude: "21.00"}
       expect(type.cast(value)).to eq([Float(10.0), Float(21.00)])
     end
 
     it 'handles an object as a JSON string' do
-      field['format'] = 'object'
+      field[:format] = 'object'
       value = '{"longitude": "10.0", "latitude": "21.00"}'
       expect(type.cast(value)).to eq([Float(10.0), Float(21.00)])
     end
 
     it 'raises for an invalid object' do
-      field['format'] = 'object'
+      field[:format] = 'object'
       value = '{"blah": "10.0", "latitude": "21.00"}'
       expect { type.cast(value) }.to raise_error(TableSchema::InvalidGeoPointType)
       value = '{"longitude": "a", "latitude": "21.00"}'
@@ -719,11 +719,11 @@ describe TableSchema::Types do
 
     let(:field) {
       TableSchema::Field.new({
-        'name' => 'Name',
-        'type' => 'any',
-        'format' => 'default',
-        'constraints' => {
-          'required' => true
+        name: 'Name',
+        type: 'any',
+        format: 'default',
+        constraints: {
+          required: true
         }
       })
     }
@@ -743,33 +743,33 @@ describe TableSchema::Types do
 
     let(:non_string_types) {
       {
-        'number' => TableSchema::Types::Number,
-        'integer' => TableSchema::Types::Integer,
-        'boolean' => TableSchema::Types::Boolean,
-        'array' => TableSchema::Types::Array,
-        'object' => TableSchema::Types::Object,
-        'date' => TableSchema::Types::Date,
-        'time' => TableSchema::Types::Time,
-        'datetime' => TableSchema::Types::DateTime,
-        'geopoint' => TableSchema::Types::GeoPoint,
-        'geojson' => TableSchema::Types::GeoJSON,
-        #'any' => TableSchema::Types::Any
+        number: TableSchema::Types::Number,
+        integer: TableSchema::Types::Integer,
+        boolean: TableSchema::Types::Boolean,
+        array: TableSchema::Types::Array,
+        object: TableSchema::Types::Object,
+        date: TableSchema::Types::Date,
+        time: TableSchema::Types::Time,
+        datetime: TableSchema::Types::DateTime,
+        geopoint: TableSchema::Types::GeoPoint,
+        geojson: TableSchema::Types::GeoJSON,
+        #any: TableSchema::Types::Any
       }
     }
 
     let(:string_types) {
       {
-        'string' => TableSchema::Types::String,
+        string: TableSchema::Types::String,
       }
     }
 
     let(:field_attrs) {
       {
-        'name' => 'Name',
-        'type' => 'string',
-        'format' => 'default',
-        'constraints' => {
-          'required' => true,
+        name: 'Name',
+        type: 'string',
+        format: 'default',
+        constraints: {
+          required: true,
         }
       }
     }
@@ -783,7 +783,7 @@ describe TableSchema::Types do
 
     it 'raises for missing_values on required fields' do
       non_string_types.each do |name, type_class|
-        field_attrs['type'] = name
+        field_attrs[:type] = name
         field = TableSchema::Field.new(field_attrs, missing_values)
         type = type_class.new(field)
         expect { type.cast('null') }.to raise_error(TableSchema::ConstraintError)
@@ -793,7 +793,7 @@ describe TableSchema::Types do
 
     it 'raises for null value on required string fields' do
       string_types.each do |name, type_class|
-        field_attrs['type'] = name
+        field_attrs[:type] = name
         field = TableSchema::Field.new(field_attrs, missing_values)
         type = type_class.new(field)
         expect { type.cast('null') }.to raise_error(TableSchema::ConstraintError)
@@ -802,9 +802,9 @@ describe TableSchema::Types do
     end
 
     it 'returns nil for optional fields' do
-      field_attrs['constraints']['required'] = false
+      field_attrs[:constraints][:required] = false
       non_string_types.each do |name, type_class|
-        field_attrs['type'] = name
+        field_attrs[:type] = name
         field = TableSchema::Field.new(field_attrs, missing_values)
         type = type_class.new(field)
         expect(type.cast('null')).to eq(nil)
@@ -813,9 +813,9 @@ describe TableSchema::Types do
     end
 
     it 'returns nil for optional string types' do
-      field_attrs['constraints']['required'] = false
+      field_attrs[:constraints][:required] = false
       string_types.each do |name, type_class|
-        field_attrs['type'] = name
+        field_attrs[:type] = name
         field = TableSchema::Field.new(field_attrs, missing_values)
         type = type_class.new(field)
         expect(type.cast('null')).to eq(nil)
@@ -824,9 +824,9 @@ describe TableSchema::Types do
     end
 
     it 'converts empty string to nil by default' do
-      field_attrs['constraints']['required'] = false
+      field_attrs[:constraints][:required] = false
       non_string_types.each do |name, type_class|
-        field_attrs['type'] = name
+        field_attrs[:type] = name
         field = TableSchema::Field.new(field_attrs)
         type = type_class.new(field)
         expect(type.cast('')).to eq(nil)
@@ -834,9 +834,9 @@ describe TableSchema::Types do
     end
 
     it 'doesn\'t convert empty string to nil for string types by default' do
-      field_attrs['constraints']['required'] = false
+      field_attrs[:constraints][:required] = false
       string_types.each do |name, type_class|
-        field_attrs['type'] = name
+        field_attrs[:type] = name.to_s
         field = TableSchema::Field.new(field_attrs)
         type = type_class.new(field)
         expect(type.cast('')).to eq('')

--- a/spec/types_spec.rb
+++ b/spec/types_spec.rb
@@ -774,7 +774,7 @@ describe TableSchema::Types do
       }
     }
 
-    let (:missing_values) {
+    let(:missing_values) {
       [
         'null',
         'NaN'

--- a/tableschema.gemspec
+++ b/tableschema.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry", "~> 0.10.0"
   spec.add_development_dependency "webmock", "~> 2.3.0"
   spec.add_development_dependency "coveralls", "~> 0.8.13"
+  spec.add_development_dependency "rubocop", "~> 0.49.1"
 
   spec.add_dependency "json-schema", "~> 2.6.0"
   spec.add_dependency "uuid", "~> 2.3.8"


### PR DESCRIPTION
Throughout the gem the `descriptor` hashes sometimes  have string keys sometimes have symbol keys. This is problematic when the values are accessed by [key name](https://github.com/frictionlessdata/tableschema-rb/blob/391fe5ac6d83d3268b6f8a798bad63601d1df1bc/lib/tableschema/field.rb#L16) because `hash[:key]` yields different from `hash['key']`.

This PR attempts to avoid such issues by converting all hash keys to symbols, as recommended by the [Ruby style guide](https://github.com/bbatsov/ruby-style-guide#symbols-as-keys).
I also set up a minimal [Rubocop](https://github.com/bbatsov/rubocop) linter just to make sure we avoid such issues in the future.