### PR TITLE
Refactor Field class & add test_value method

### DIFF
--- a/spec/field_spec.rb
+++ b/spec/field_spec.rb
@@ -4,6 +4,12 @@ describe TableSchema::Field do
 
   before(:each) do
     @descriptor_min = {name: 'id'}
+    @descriptor_min_processed = {
+      name: 'id',
+      type: 'string',
+      format: 'default',
+      constraints: {}
+    }
     @descriptor_max = {
       name: 'amount',
       type: 'number',
@@ -12,8 +18,8 @@ describe TableSchema::Field do
     }
   end
 
-  it 'returns the descriptor' do
-    expect(described_class.new(@descriptor_min)).to eq(@descriptor_min)
+  it 'returns the descriptor with defaults' do
+    expect(described_class.new(@descriptor_min)).to eq(@descriptor_min_processed)
   end
 
   it 'returns a name' do
@@ -36,23 +42,26 @@ describe TableSchema::Field do
   end
 
   it 'returns the correct type class' do
-    expect(described_class.new(@descriptor_min).type_class).to eq(TableSchema::Types::String)
-    expect(described_class.new(@descriptor_max).type_class).to eq(TableSchema::Types::Number)
+    expect(described_class.new(@descriptor_min).send(:type_class)).to eq(TableSchema::Types::String)
+    expect(described_class.new(@descriptor_max).send(:type_class)).to eq(TableSchema::Types::Number)
   end
 
-  it 'casts a value' do
-    expect(described_class.new(@descriptor_min).cast_value('string')).to eq('string')
-  end
-
-  it 'casts a single value' do
+  it 'cast_value casts valid value' do
     expect(described_class.new(@descriptor_max).cast_value('£10')).to eq(Float(10.0))
   end
 
-  it 'raises with an incorrect value' do
+  it 'cast_value raises with an incorrect value' do
     expect { described_class.new(@descriptor_max).cast_value('notdecimal') }.to raise_error(
       TableSchema::InvalidCast,
       'notdecimal is not a number'
     )
   end
 
+  it 'test_value returns true for valid value' do
+    expect(described_class.new(@descriptor_max).test_value('30.78')).to be true
+  end
+
+  it 'test_value returns false for invalid value' do
+    expect(described_class.new(@descriptor_min).test_value(100)).to be false
+  end
 end

--- a/spec/infer_spec.rb
+++ b/spec/infer_spec.rb
@@ -105,7 +105,7 @@ describe TableSchema::Infer do
     inferer = TableSchema::Infer.new(headers, data, explicit: false)
     schema = inferer.schema
 
-    expect(schema.get_field('id')[:constraints]).to be_nil
+    expect(schema.get_field('id')[:constraints]).to be_empty
   end
 
 end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -15,13 +15,15 @@ describe TableSchema::Table do
           name: "id",
           title: "Identifier",
           type: "integer",
-          format: "default"
+          format: "default",
+          constraints: {}
         },
         {
           name: "title",
           title: "Title",
           type: "string",
-          format: "default"
+          format: "default",
+          constraints: {}
         }
       ]
     })
@@ -122,14 +124,16 @@ describe TableSchema::Table do
           title: "",
           description: "",
           type: "integer",
-          format: "default"
+          format: "default",
+          constraints: {}
         },
         {
           name: "title",
           title: "",
           description: "",
           type: "string",
-          format: "default"
+          format: "default",
+          constraints: {}
         }
       ]
     })


### PR DESCRIPTION
Fixes #18

---

Functionality changes:
- `field.descriptor` now returns all the attributes not just the ones passed by the user:
    e.g.

   ```ruby
        f = Field.new({name: 'default_field'})
        f.descriptor 
        # => {name: 'default_field', type: 'string', format: 'default', constraints: {}}
   ```

  I consider this to be more transparent for users than showing `fielf = {name: 'default_field'}`.

- added `field.test_value(value)` method that returns `true` for valid value and `false` for invalid value

 Code changes:
- since in Ruby using `attr_reader :instance_variable` creates getters automatically I replaced the `name`, `format`, `type` and `constraints` methods with instance variables.

