### PR TITLE
Fix casting of nil Integer values

### DIFF
--- a/lib/tableschema/types/integer.rb
+++ b/lib/tableschema/types/integer.rb
@@ -22,7 +22,7 @@ module TableSchema
       end
 
       def cast_default(value)
-        if value.is_a?(type)
+        if value.nil? || value.is_a?(type)
           value
         else
           bare_number = @field.fetch(:bareNumber, TableSchema::DEFAULTS[:bare_number])

--- a/spec/types/integer_spec.rb
+++ b/spec/types/integer_spec.rb
@@ -18,6 +18,11 @@ describe TableSchema::Types::Integer do
     expect(type.cast(value)).to eq(1)
   end
 
+  it 'casts nil values in integer columns' do
+    value = nil
+    expect(type.cast(value)).to be nil
+  end
+
   it 'raises when the value is not an integer' do
     value = 'string1'
     expect { type.cast(value) }.to raise_error(TableSchema::InvalidCast)


### PR DESCRIPTION
Avoids the current `TypeError: can't convert nil into Integer` when an integer column contains a blank value.